### PR TITLE
Avoid loops if transmission to api.logentries.com fails

### DIFF
--- a/Push-Queue/logentries.py
+++ b/Push-Queue/logentries.py
@@ -9,24 +9,25 @@
 from google.appengine.ext import webapp
 from google.appengine.api import urlfetch
 from google.appengine.api import taskqueue
+from google.appengine.runtime import apiproxy_errors
 
 import logging
 
 def init(key, location):
-	if len(logging.getLogger('').handlers) <= 1:
-		logging.getLogger('').addHandler(PushQueue(key, location))
+    if len(logging.getLogger('').handlers) <= 1:
+        logging.getLogger('').addHandler(PushQueue(key, location))
 
 class LogentriesWorker(webapp.RequestHandler):
 
-   	def post(self):
-      		rpc = urlfetch.create_rpc()
-      		msg = self.request.get('msg')
-      		addr = self.request.get('addr')
-		try:
-      			urlfetch.make_fetch_call(rpc, addr, payload = msg, method=urlfetch.PUT, headers={'content-length':str(len(msg))})
-		except apiproxy_errors.OverQuotaError, message:
-			logging.error(message)
-			logging.error("URLFetch API Quota reached, unable to transmit logs to Logentries")
+    def post(self):
+        rpc = urlfetch.create_rpc()
+        msg = self.request.get('msg')
+        addr = self.request.get('addr')
+        try:
+            urlfetch.make_fetch_call(rpc, addr, payload = msg, method=urlfetch.PUT, headers={'content-length':str(len(msg))})
+        except apiproxy_errors.OverQuotaError, message:
+            logging.error(message)
+            logging.error("URLFetch API Quota reached, unable to transmit logs to Logentries")
 
 
 class PushQueue(logging.Handler):
@@ -35,36 +36,26 @@ class PushQueue(logging.Handler):
 
         logging.Handler.__init__(self)
         self.addr = 'https://api.logentries.com/%s/hosts/%s/?realtime=1' %(key, location)
-	format = logging.Formatter('%(asctime)s : %(levelname)s, %(message)s', '%a %b %d %H:%M:%S %Z %Y')
-	self.setFormatter(format)
-  
+        format = logging.Formatter('%(asctime)s : %(levelname)s, %(message)s', '%a %b %d %H:%M:%S %Z %Y')
+        self.setFormatter(format)
+
 
     def send(self, msg):
-	try:
-        	taskqueue.add(queue_name='logentries-push-queue', url='/logentriesworker', params={'msg':msg, 'addr':self.addr})
-	except apiproxy_errors.OverQuotaError, message:
-		logging.error(message)
-		logging.error("TaskQueue API Quota reached, unable to transmit logs to Logentries")
+        try:
+            taskqueue.add(queue_name='logentries-push-queue', url='/logentriesworker', params={'msg':msg, 'addr':self.addr})
+        except apiproxy_errors.OverQuotaError, message:
+            logging.error(message)
+            logging.error("TaskQueue API Quota reached, unable to transmit logs to Logentries")
 
     def handleError(self, record):
         pass
 
-
     def emit(self, record):
-
-	msg = self.format(record)
+        msg = self.format(record)
         self.send(msg+'\n')
 
-
     def flush(self):
-	pass
+        pass
 
     def close(self):
-
         logging.Handler.close(self)
-
-
-
-
-
-


### PR DESCRIPTION
If writing to api.logentries.com fails or taskqueue enqueuing fails we gat a nasty loop.

This patch breaks the loop by avoiding the
Python logging infrastructure and dumping
errors happened during logging just so
STDERR which will go into the appengine logs.